### PR TITLE
Improve advising safety guardrails

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -24,7 +24,7 @@ function formatCourseForPrompt(course: Course): string {
         ? course.prerequisites.join(", ")
         : "None";
   const ge = course.ge_areas.length > 0 ? course.ge_areas.join(", ") : "None";
-  return `${course.code} — ${course.title} (${course.units} units). Prerequisites: ${prereqs}. GE: ${ge}. ${course.description}`;
+  return `${course.code} — ${course.title} (${course.units} units). Prerequisites: ${prereqs}. GE: ${ge}. ${course.description} Source: local UC Davis course catalog dataset (courses.json / courses-full.json).`;
 }
 
 // --- Cached data for chat route ---
@@ -71,7 +71,7 @@ function formatSectionForPrompt(section: Section): string {
   const instructors =
     section.instructors.length > 0 ? section.instructors.join(", ") : "TBA";
 
-  let base = `${section.courseCode} ${section.section || ""} — CRN ${section.crn} with ${instructors}. Meetings: ${meetings}. ${seats}.`;
+  let base = `${section.courseCode} ${section.section || ""} — CRN ${section.crn} with ${instructors}. Meetings: ${meetings}. ${seats}. Source: Spring 2026 UC Davis section snapshot (data/sections/spring-2026.json).`;
 
   // Enrich with RMP data
   const rmp = loadRmpData();
@@ -84,7 +84,9 @@ function formatSectionForPrompt(section: Section): string {
     if (r.wouldTakeAgainPercent != null && r.wouldTakeAgainPercent >= 0)
       parts.push(`Would Take Again: ${r.wouldTakeAgainPercent}%`);
     if (r.numRatings) parts.push(`${r.numRatings} reviews`);
-    if (parts.length > 0) base += ` RMP: ${parts.join(", ")}.`;
+    if (parts.length > 0) {
+      base += ` RMP student-review data: ${parts.join(", ")}. Source: Rate My Professors snapshot (data/rmp.json).`;
+    }
   }
 
   // Enrich with CattleLog grade data
@@ -232,7 +234,7 @@ export async function POST(req: Request) {
     for (const c of courses) {
       const g = grades[c.code];
       if (g && g.overall_gpa != null) {
-        let snippet = `Grade data for ${c.code}: Overall GPA ${g.overall_gpa}, ${g.overall_enrolled} students.`;
+        let snippet = `Grade data for ${c.code}: Overall GPA ${g.overall_gpa}, ${g.overall_enrolled} students. Source: CattleLog historical grade distribution snapshot (data/grades.json).`;
         if (g.overall_grades) {
           const dist = g.overall_grades;
           const total = Object.values(dist).reduce((a: number, b: any) => a + (b as number), 0);

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -81,6 +81,11 @@ export function Chat({ studentContext }: ChatProps) {
                   academic planning. I&apos;m here to help you navigate your UC
                   Davis journey.
                 </p>
+                <p className="mt-2 max-w-sm rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-200">
+                  Adviso is not an official UC Davis advisor. Verify enrollment,
+                  prerequisite, and graduation decisions with UC Davis advising
+                  or official catalog sources.
+                </p>
               </div>
               <div className="grid w-full max-w-sm grid-cols-1 gap-1.5 sm:grid-cols-2">
                 {exampleQuestions.map((q: string) => (

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,8 @@ Use Slack for fast capture and discussion. Use these Markdown docs for organized
 - [Meeting Notes](./meeting-notes.md)
 - [User Research](./user-research.md)
 - [Compliance Notes](./compliance-notes.md)
+- [Advising Safety](./advising-safety.md)
+- [Source and Citation Pattern](./source-citation-pattern.md)
 - [Operating Notes](./operating-notes.md)
 
 ## Working Rule

--- a/docs/advising-safety.md
+++ b/docs/advising-safety.md
@@ -1,0 +1,24 @@
+# Advising Safety Notes
+
+Adviso should be useful and confident where the data supports it, but conservative when a student may make enrollment, prerequisite, or graduation decisions from the answer.
+
+## Product posture
+
+- Adviso is not an official UC Davis advisor.
+- Requirement and prerequisite guidance should be grounded in available catalog/course/section data.
+- Plans are provisional when student context is incomplete, including catalog year, transfer credit, AP/IB credit, petitions, repeated courses, grades, or emphasis/specialization.
+- The assistant should distinguish official/source-backed facts from recommendations and assumptions.
+
+## Current first-pass guardrails
+
+- System prompt explicitly says not to claim official advisor status.
+- System prompt requires uncertainty when reference data is missing or incomplete.
+- System prompt asks responses to include basis/source context for advising claims.
+- Home chat screen now displays a visible non-official-advisor disclaimer.
+
+## Follow-up work
+
+- Add source links/citations in the UI when data includes official URLs.
+- Improve prerequisite parsing/validation before suggesting enrollment order.
+- Add transcript privacy disclosure around uploads.
+- Add a confidence/verification pattern for generated quarter plans.

--- a/docs/source-citation-pattern.md
+++ b/docs/source-citation-pattern.md
@@ -1,0 +1,40 @@
+# Source and Citation Pattern
+
+Adviso should make academic advice traceable without pretending to be an official UC Davis system. The goal is not legalistic footnotes; it is enough source visibility that a student can tell whether a claim came from catalog data, section data, historical grades, reviews, or inference.
+
+## Current Source Categories
+
+- **Local UC Davis course catalog data**: course titles, units, descriptions, prerequisites, GE areas, and offered terms from `data/courses.json` and `data/courses-full.json`.
+- **Retrieved UC Davis catalog / degree text**: RAG snippets from `data/embeddings.json`, usually generated from catalog/program requirement snapshots.
+- **Spring 2026 section snapshot**: section times, CRNs, instructors, seats, and locations from `data/sections/spring-2026.json`.
+- **CattleLog historical grade data**: historical GPA and grade distributions from `data/grades.json`; should be framed as context, not prediction.
+- **Rate My Professors student-review data**: review-derived instructor ratings from `data/rmp.json`; should be framed as student-review signal, not official quality measurement.
+
+## Product Rule
+
+When Adviso answers an advising-sensitive question, it should include a short **What I’m basing this on** section whenever it uses catalog, course, section, grade, or review data.
+
+Good examples:
+
+- “What I’m basing this on: local UC Davis course catalog data for ECS 036A and retrieved UC Davis catalog requirement text for Computer Science, B.S.”
+- “What I’m basing this on: Spring 2026 section snapshot for CRN/time/instructor data; CattleLog historical grade data for grade distribution context.”
+
+Avoid:
+
+- Citing source categories that were not actually present in the model context.
+- Treating CattleLog or RMP as official UC Davis advice.
+- Hiding uncertainty behind confident language.
+- Using source notes as a substitute for official verification when a decision affects enrollment, graduation, prerequisites, petitions, or transfer/AP/IB credit.
+
+## Implementation Notes
+
+The chat route now annotates retrieved course, section, grade, and RAG snippets with source notes before they enter the model prompt. The system prompt asks the model to surface the relevant source categories in its answer.
+
+This is an MVP pattern. A stronger future version should pass structured source metadata through the API and render citations in the UI instead of relying entirely on model text generation.
+
+## Next Improvements
+
+1. Add source URLs for program/catalog pages where available in `data/majors/*.json`.
+2. Render source badges or expandable citations in message bubbles.
+3. Add regression examples for high-stakes answers: prerequisites, remaining requirements, GE fulfillment, transfer/AP/IB credit, and quarter plans.
+4. Track source freshness dates for section, grade, and scraped catalog datasets.

--- a/lib/rag.ts
+++ b/lib/rag.ts
@@ -1,4 +1,16 @@
 import { findSimilar } from "./embeddings";
+import type { EmbeddingEntry } from "./course-data";
+
+function formatReferenceSource(metadata: EmbeddingEntry["metadata"]): string {
+  const type = metadata.type.replaceAll("_", " ");
+  const source = metadata.source;
+
+  if (source.endsWith(".json")) {
+    return `UC Davis catalog snapshot (${type}; data source: ${source})`;
+  }
+
+  return `Retrieved academic reference (${type}; data source: ${source})`;
+}
 
 export async function retrieve(
   query: string,
@@ -8,5 +20,8 @@ export async function retrieve(
 
   return results
     .filter((r) => r.score > 0.3)
-    .map((r) => r.entry.text);
+    .map((r, i) => {
+      const source = formatReferenceSource(r.entry.metadata);
+      return `[Reference ${i + 1} source: ${source}]\n${r.entry.text}`;
+    });
 }

--- a/lib/system-prompt.ts
+++ b/lib/system-prompt.ts
@@ -34,6 +34,8 @@ Guidelines:
 Response pattern for advising answers:
 - Start with the direct answer.
 - Then include "What I’m basing this on" when using catalog, course, section, or grade data.
+- In "What I’m basing this on", name the source category from the provided context, such as local UC Davis course catalog data, retrieved UC Davis catalog/degree text, Spring 2026 section snapshot, CattleLog historical grade data, or Rate My Professors student-review data.
+- Do not cite a source category unless it appeared in the provided context for this answer.
 - Include "Please verify" when the answer affects enrollment, graduation, prerequisites, major changes, petitions, or transfer/AP/IB credit.
 
 INTERACTIVE COURSE CARDS:
@@ -115,8 +117,8 @@ Rules for schedule blocks:
 
   if (ragChunks.length > 0) {
     parts.push(
-      "Retrieved UC Davis catalog / degree requirement reference text. Cite this as the basis for requirement claims, but still flag ambiguity when the retrieved text is incomplete or conflicts with other data:\n\n" +
-        ragChunks.map((chunk, i) => `[Reference ${i + 1}] ${chunk}`).join("\n\n")
+      "Retrieved UC Davis catalog / degree requirement reference text. Use the included source line for each reference in the 'What I’m basing this on' section, but still flag ambiguity when the retrieved text is incomplete or conflicts with other data:\n\n" +
+        ragChunks.join("\n\n")
     );
   }
 

--- a/lib/system-prompt.ts
+++ b/lib/system-prompt.ts
@@ -9,18 +9,32 @@ export function buildSystemPrompt(
 ): string {
   const parts: string[] = [];
 
-  parts.push(`You are a friendly and knowledgeable UC Davis academic advisor AI assistant. Your role is to help students navigate course requirements, prerequisites, degree planning, and academic policies.
+  parts.push(`You are Adviso, a friendly UC Davis academic planning assistant. Your role is to help students understand courses, prerequisites, degree requirements, schedules, and academic policies.
+
+Critical safety and trust rules:
+- You are NOT an official UC Davis advisor. Never imply your answer is official, guaranteed, or a substitute for confirming with UC Davis advising, the General Catalog, department pages, or the student's college.
+- Treat academic planning as high-stakes: a wrong prerequisite, missing requirement, or bad quarter plan can delay graduation.
+- Do not guess. If the reference material does not support a claim, say what is unknown and suggest how to verify it.
+- Separate facts from advice. Use language like "The data I have shows...", "A reasonable next step may be...", and "Please verify this with..." when appropriate.
+- For prerequisites and degree requirements, be conservative: if a course may require another course, placement, petition, minimum grade, concurrent enrollment, or advisor approval, mention the uncertainty instead of smoothing it over.
+- If student-provided context is incomplete (transfer credit, AP/IB credit, catalog year, repeated courses, petitions, grades, or major emphasis), say that the plan is provisional.
+- Do not invent courses, CRNs, prerequisites, GE areas, instructors, seats, GPA data, or requirement rules.
 
 Guidelines:
 - Always refer to courses by their official code (e.g., "PHI 001", "ECN 100A").
-- When discussing requirements, be specific about which courses satisfy them.
+- When discussing requirements, be specific about which courses satisfy them and where your information came from: course details, section data, grade data, or retrieved catalog/requirement text.
 - If you are unsure or the information is not in your reference material, say so honestly rather than guessing.
 - Keep responses concise but thorough. Use bullet points or numbered lists for clarity when listing courses or requirements.
-- Be encouraging and supportive in tone, like a real academic advisor would be.
+- Be encouraging and supportive in tone, but do not overstate certainty like a real official advisor would.
 - Only answer questions related to UC Davis academics, courses, and degree planning. Politely redirect off-topic questions.
-- When a student asks about remaining requirements, cross-reference their completed courses with the degree requirements to identify what's left.
-- You have access to Rate My Professors (RMP) data including instructor ratings, difficulty scores, and "would take again" percentages. You can share this data when students ask about instructors or want recommendations.
-- You have access to CattleLog grade distribution data including historical GPAs, grade breakdowns (A+ through F), and per-professor grade distributions. Share this data when students ask about course difficulty, grade distributions, or want to compare instructors.
+- When a student asks about remaining requirements, cross-reference their completed courses with the degree requirements to identify what's left, then clearly state assumptions and gaps.
+- You have access to Rate My Professors (RMP) data including instructor ratings, difficulty scores, and "would take again" percentages. You can share this data when students ask about instructors or want recommendations, but describe it as student-review data, not an official quality measure.
+- You have access to CattleLog grade distribution data including historical GPAs, grade breakdowns (A+ through F), and per-professor grade distributions. Share this data when students ask about course difficulty, grade distributions, or want to compare instructors, but remind students that historical grades do not guarantee future outcomes.
+
+Response pattern for advising answers:
+- Start with the direct answer.
+- Then include "What I’m basing this on" when using catalog, course, section, or grade data.
+- Include "Please verify" when the answer affects enrollment, graduation, prerequisites, major changes, petitions, or transfer/AP/IB credit.
 
 INTERACTIVE COURSE CARDS:
 When you recommend a specific course and section data is available, include an interactive card the student can use to add it directly to their schedule. Use this exact format:
@@ -78,14 +92,14 @@ Rules for schedule blocks:
 
   if (mentionedCourses.length > 0) {
     parts.push(
-      "Specific course details (exact data from the catalog):\n\n" +
+      "Course details retrieved from local catalog data. Use only the fields shown here; if a needed field is missing, say it is not available in the current data:\n\n" +
         mentionedCourses.map((c, i) => `[Course ${i + 1}] ${c}`).join("\n\n")
     );
   }
 
   if (sectionSnippets.length > 0) {
     parts.push(
-      "Live schedule information for Spring Quarter 2026 (sections, times, instructors, and open seats):\n\n" +
+      "Spring Quarter 2026 section data. Treat seats, instructors, rooms, and times as point-in-time data that students should verify in Schedule Builder before enrolling:\n\n" +
         sectionSnippets
           .map((s, i) => `[Section ${i + 1}] ${s}`)
           .join("\n\n")
@@ -94,15 +108,15 @@ Rules for schedule blocks:
 
   if (gradeSnippets.length > 0) {
     parts.push(
-      "Historical grade distribution data from CattleLog (real UC Davis records):\n\n" +
+      "Historical CattleLog grade distribution data. Use for context only; do not imply it predicts a student's grade or course quality with certainty:\n\n" +
         gradeSnippets.map((g, i) => `[Grades ${i + 1}] ${g}`).join("\n\n")
     );
   }
 
   if (ragChunks.length > 0) {
     parts.push(
-      "Reference material from the UC Davis course catalog and degree requirements:\n\n" +
-        ragChunks.map((chunk, i) => `[${i + 1}] ${chunk}`).join("\n\n")
+      "Retrieved UC Davis catalog / degree requirement reference text. Cite this as the basis for requirement claims, but still flag ambiguity when the retrieved text is incomplete or conflicts with other data:\n\n" +
+        ragChunks.map((chunk, i) => `[Reference ${i + 1}] ${chunk}`).join("\n\n")
     );
   }
 


### PR DESCRIPTION
## Summary
- strengthens the chat system prompt around non-official-advisor positioning, uncertainty, and source-backed advice
- adds a visible disclaimer on the empty chat screen
- annotates course, section, RMP, CattleLog, and RAG snippets with source notes before they enter the model prompt
- documents the initial advising safety posture and the MVP source/citation pattern under docs/

## Verification
- npm run build

Closes #1
Closes #5