### PR TITLE
Add transcript privacy disclosure

### DIFF
--- a/app/api/parse-transcript/route.ts
+++ b/app/api/parse-transcript/route.ts
@@ -1,6 +1,14 @@
 import { NextResponse } from "next/server";
 import { extractCourseMentions } from "@/lib/course-lookup";
 
+const MAX_TRANSCRIPT_CHARS = 50_000;
+
+function transcriptJson(body: unknown, init?: ResponseInit) {
+  const headers = new Headers(init?.headers);
+  headers.set("Cache-Control", "no-store");
+  return NextResponse.json(body, { ...init, headers });
+}
+
 export async function POST(req: Request) {
   try {
     const { transcript } = (await req.json()) as {
@@ -8,21 +16,33 @@ export async function POST(req: Request) {
     };
 
     if (!transcript || typeof transcript !== "string") {
-      return NextResponse.json(
+      return transcriptJson(
         { error: "Missing 'transcript' text" },
         { status: 400 }
+      );
+    }
+
+    if (transcript.length > MAX_TRANSCRIPT_CHARS) {
+      return transcriptJson(
+        {
+          error:
+            "Transcript text is too long. Paste only the completed-course section or add courses manually.",
+        },
+        { status: 413 }
       );
     }
 
     const courses = await extractCourseMentions(transcript);
     const codes = Array.from(new Set(courses.map((c) => c.code))).sort();
 
-    return NextResponse.json({
+    return transcriptJson({
       count: codes.length,
       codes,
+      privacy:
+        "Transcript text is parsed for course codes only and is not returned or cached by this endpoint.",
     });
   } catch {
-    return NextResponse.json(
+    return transcriptJson(
       { error: "Failed to parse transcript" },
       { status: 500 }
     );

--- a/components/onboarding.tsx
+++ b/components/onboarding.tsx
@@ -570,10 +570,17 @@ export function Onboarding({
                 </h2>
               </div>
             </div>
-            <p className="mb-6 px-10 max-w-lg text-sm text-gray-500">
+            <p className="mb-3 px-10 max-w-lg text-sm text-gray-500">
               We&apos;ll scan it for course codes (e.g., ECN 001, MAT 021B) and
               mark them as completed in your degree audit.
             </p>
+            <div className="mx-10 mb-4 max-w-lg rounded-xl border border-blue-100 bg-blue-50 px-3 py-2 text-[11px] leading-relaxed text-blue-900">
+              <span className="font-semibold">Privacy note:</span> paste only what
+              you&apos;re comfortable sharing. Adviso sends this text to its parser to
+              extract course codes, then keeps only the detected course list in
+              your profile. Avoid including SSNs, student IDs, addresses, or other
+              unnecessary personal details.
+            </div>
 
             <div className="flex min-h-0 flex-1 flex-col gap-4 px-10 max-w-xl pr-2">
               <textarea

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ Use Slack for fast capture and discussion. Use these Markdown docs for organized
 - [Meeting Notes](./meeting-notes.md)
 - [User Research](./user-research.md)
 - [Compliance Notes](./compliance-notes.md)
+- [Transcript Privacy Behavior](./transcript-privacy.md)
 - [Operating Notes](./operating-notes.md)
 
 ## Working Rule

--- a/docs/transcript-privacy.md
+++ b/docs/transcript-privacy.md
@@ -1,0 +1,36 @@
+# Transcript Privacy Behavior
+
+Adviso lets a student paste unofficial transcript text during onboarding so the app can detect completed UC Davis course codes and pre-fill the degree audit.
+
+This is useful, but transcript text can contain sensitive academic and personal information. Treat this as privacy-sensitive even before Adviso has formal legal/compliance review.
+
+## Current Product Behavior
+
+- Transcript paste is optional and skippable.
+- The transcript parser extracts course codes and returns a unique sorted list.
+- The frontend stores completed course codes in the student profile state.
+- The parser response does not return the original transcript text.
+- The parser endpoint now sends `Cache-Control: no-store` on responses.
+- The parser rejects very large pasted transcripts over 50,000 characters and asks the student to paste only the completed-course section or add courses manually.
+- The onboarding UI now warns students to avoid unnecessary personal details such as SSNs, student IDs, addresses, and other identifiers.
+
+## Product Principle
+
+Adviso should prefer data minimization:
+
+1. Ask for only what is needed.
+2. Keep derived academic planning facts where possible, not raw sensitive documents.
+3. Explain what is happening in plain language before the student pastes anything.
+4. Make manual entry and skipping easy.
+
+## Current Gaps / Follow-Up
+
+- Confirm whether completed courses persist only locally or are saved server-side in any future account system.
+- Add a formal privacy policy before any broad pilot.
+- Add a deletion/export path if transcripts, completed-course lists, or advising profiles become account-backed.
+- Avoid sending raw transcript text to third-party LLMs unless the user explicitly opts in and the privacy policy supports it.
+- Add test coverage for parser limits and `Cache-Control: no-store` behavior.
+
+## Suggested User-Facing Copy
+
+> Paste only what you’re comfortable sharing. Adviso uses this text to detect completed course codes, then keeps only the detected course list in your profile. Avoid including SSNs, student IDs, addresses, or other unnecessary personal details.


### PR DESCRIPTION
## Summary
- adds a visible privacy note before students paste unofficial transcript text
- adds no-store responses and a 50,000-character limit to the transcript parser endpoint
- documents current transcript privacy behavior and follow-up gaps in docs/transcript-privacy.md

## Verification
- npm run build

Closes #6