### PR TITLE
Add first plan starter CTA

### DIFF
--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -9,6 +9,16 @@ interface ChatProps {
   studentContext: StudentContext;
 }
 
+function getFirstPlanPrompt(studentContext: StudentContext): string {
+  const major = studentContext.major || "my major";
+  const year = studentContext.year || "my year";
+  const completed = studentContext.completedCourses?.length
+    ? ` I have completed: ${studentContext.completedCourses.join(", ")}.`
+    : " I have not added completed courses yet.";
+
+  return `Build my first academic plan for ${major} as a ${year}.${completed} Start with the next 3-5 actions I should take, flag any assumptions or missing information, and suggest a reasonable next-quarter course direction.`;
+}
+
 function getExampleQuestions(major: string): string[] {
   if (!major) {
     return [
@@ -37,6 +47,10 @@ export function Chat({ studentContext }: ChatProps) {
   const exampleQuestions = useMemo(
     () => getExampleQuestions(studentContext.major),
     [studentContext.major]
+  );
+  const firstPlanPrompt = useMemo(
+    () => getFirstPlanPrompt(studentContext),
+    [studentContext]
   );
 
   const isLoading = status === "submitted" || status === "streaming";
@@ -82,6 +96,23 @@ export function Chat({ studentContext }: ChatProps) {
                   Davis journey.
                 </p>
               </div>
+              <button
+                type="button"
+                onClick={() => handleSend(firstPlanPrompt)}
+                disabled={isLoading}
+                className="w-full max-w-sm rounded-2xl border border-[#002855]/15 bg-white px-4 py-3 text-left shadow-sm transition-all hover:-translate-y-0.5 hover:border-[#002855]/35 hover:shadow-md disabled:cursor-not-allowed disabled:opacity-60 dark:border-blue-400/20 dark:bg-slate-800 dark:hover:border-blue-300/40"
+              >
+                <div className="text-xs font-semibold uppercase tracking-wide text-[#DAAA00]">
+                  Best first step
+                </div>
+                <div className="mt-1 text-sm font-semibold text-gray-900 dark:text-white">
+                  Build my first academic plan
+                </div>
+                <div className="mt-1 text-xs leading-relaxed text-gray-500 dark:text-slate-400">
+                  Use my major, year, and completed courses to identify next
+                  actions, assumptions, and a reasonable next-quarter direction.
+                </div>
+              </button>
               <div className="grid w-full max-w-sm grid-cols-1 gap-1.5 sm:grid-cols-2">
                 {exampleQuestions.map((q: string) => (
                   <button

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ Use Slack for fast capture and discussion. Use these Markdown docs for organized
 - [Decisions](./decisions.md)
 - [Meeting Notes](./meeting-notes.md)
 - [User Research](./user-research.md)
+- [Onboarding to First Useful Plan](./onboarding-first-plan.md)
 - [Compliance Notes](./compliance-notes.md)
 - [Operating Notes](./operating-notes.md)
 

--- a/docs/onboarding-first-plan.md
+++ b/docs/onboarding-first-plan.md
@@ -1,0 +1,35 @@
+# Onboarding to First Useful Plan
+
+Adviso should not end onboarding with a blank chatbot. The first post-onboarding experience should make the next action obvious: turn the student's major, year, completed courses, and availability into a useful first academic plan.
+
+## Current Improvement
+
+The empty chat state now includes a featured **Build my first academic plan** call-to-action above the smaller example prompts.
+
+The generated prompt asks Adviso to:
+
+- use the selected major and year,
+- include completed courses if the student added or parsed them,
+- start with the next 3-5 actions,
+- flag assumptions or missing information,
+- suggest a reasonable next-quarter course direction.
+
+This turns onboarding inputs into an immediate planning conversation instead of leaving the student to invent the first question.
+
+## Why This Matters
+
+A student trying Adviso for the first time is likely asking, “What should I do next?” A strong first-run path should quickly demonstrate value while still preserving safety and uncertainty.
+
+The first plan should be:
+
+- **Actionable**: concrete next steps, not a generic welcome.
+- **Provisional**: clear about missing catalog year, transfer/AP/IB credit, petitions, repeated courses, and official advisor verification.
+- **Grounded**: based on the student profile and available catalog/course data.
+- **Easy to continue**: naturally leads into degree audit, schedule planning, or follow-up questions.
+
+## Follow-Up Ideas
+
+1. After onboarding, automatically highlight the AI panel's first-plan CTA or open the chat panel focused on it.
+2. Add a first-run checklist next to the degree audit: verify completed courses, review remaining requirements, build next-quarter schedule.
+3. Add lightweight telemetry for which starter prompts students click, once analytics/privacy posture is approved.
+4. Add regression examples for first-plan responses across freshman, transfer, senior, and undeclared/uncertain profiles.


### PR DESCRIPTION
## Summary
- adds a featured empty-chat CTA that turns onboarding profile data into a first academic plan prompt
- uses major, year, and completed courses to ask for next actions, assumptions, and next-quarter direction
- documents the onboarding-to-first-plan product pattern in docs/onboarding-first-plan.md

## Verification
- npm run build

Closes #4