### PR TITLE
Add program data quality audit

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ Use Slack for fast capture and discussion. Use these Markdown docs for organized
 ## Index
 
 - [Product Roadmap](./product-roadmap.md)
+- [Program Requirement Data Quality Audit](./data-quality-audit.md)
 - [Decisions](./decisions.md)
 - [Meeting Notes](./meeting-notes.md)
 - [User Research](./user-research.md)

--- a/docs/data-quality-audit.md
+++ b/docs/data-quality-audit.md
@@ -1,0 +1,79 @@
+# Program Requirement Data Quality Audit
+
+This first-pass audit checks whether course references in `data/majors/*.json` can be resolved against the local course catalog datasets (`data/courses.json` and `data/courses-full.json`). It is intended to support issue #3: verifying UC Davis program requirement data before students rely on degree-audit or planning output.
+
+## How to Reproduce
+
+Run:
+
+```bash
+npm run audit-program-data
+```
+
+The script scans all major/program JSON files and reports unresolved course references, grouped by likely cleanup category and by affected program.
+
+## Snapshot Results
+
+Audit date: 2026-04-29.
+
+- Program files scanned: **237**
+- Local course codes loaded: **10,462**
+- Requirement course references scanned: **16,288**
+- Resolved references: **15,585**
+- Unresolved references: **703**
+- Coverage: **95.7%**
+
+## Main Finding
+
+Most unresolved references do not look like missing UC Davis courses. They look like scraper/normalization issues that can cause Adviso to misunderstand requirement structure:
+
+| Category | Count | Meaning |
+| --- | ---: | --- |
+| Concatenated course sequence | 389 | Multiple courses were fused into one string, e.g. `MAT 021AMAT 021BMAT 021C`. |
+| Other format | 158 | Cross-listed, unusual, or malformed references that need parser-specific handling. |
+| Discontinued or annotated | 72 | Requirement entries include status notes like `DISCONTINUED FOR WINTER 2026`. |
+| Missing from course catalog | 63 | Single course-like references that were not found in local catalog data. |
+| Concatenated same-subject sequence | 21 | Same-subject sequences were fused, e.g. `ANS 041041L`. |
+
+## Programs With Most Unresolved References
+
+Top affected programs in the current snapshot:
+
+1. International Relations, B.A. — 26
+2. Applied Chemistry, B.S. — 24
+3. Environmental Science & Management, B.S. — 22
+4. Music, B.A. — 22
+5. Genetics & Genomics, B.S. — 21
+6. Neurobiology, Physiology, & Behavior, B.S. — 21
+7. Psychology, B.S. — 18
+8. Geology, B.S. — 17
+9. Human Biology, B.S. — 17
+10. Marine & Coastal Science, B.S. — 17
+
+## Examples
+
+- `EAE 130AEAE 130B` should likely be split into `EAE 130A` and `EAE 130B`.
+- `MAT 017AMAT 017BMAT 017C` should likely be split into the MAT 017 series.
+- `CHE 002ACHE 002BCHE 002C` should likely be split into the CHE 002 series.
+- `ABT/LED 150/LDA 150 DISCONTINUED FOR WINTER 2026 **` should preserve discontinuation metadata separately from course identity.
+- `PSC 123/NPB 152` is cross-listed but needs expansion/normalization before matching.
+
+## Product Risk
+
+If left uncleaned, these issues can make Adviso:
+
+- undercount completed requirements,
+- recommend a course sequence as if it were one course,
+- miss valid cross-listed courses,
+- fail to explain choice groups correctly,
+- overstate confidence in degree-audit output.
+
+For advising-sensitive answers, Adviso should continue to say plans are provisional and ask students to verify against official UC Davis sources.
+
+## Recommended Next Steps
+
+1. Improve scraper normalization for concatenated course sequences.
+2. Add explicit support for cross-listed courses where departments differ but the course number is shared.
+3. Store discontinued/annotation text as metadata instead of inside the course code string.
+4. Re-run `npm run audit-program-data` after cleanup and track unresolved count toward zero.
+5. Add this audit to a lightweight data QA checklist before any pilot or public launch.

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "scrape-courses": "tsx scripts/scrape-courses.ts",
     "scrape-programs": "tsx scripts/scrape-programs.ts",
     "scrape-sections": "tsx scripts/scrape-sections.ts",
-    "fetch-catalog": "tsx scripts/fetch-catalog-sections.ts"
+    "fetch-catalog": "tsx scripts/fetch-catalog-sections.ts",
+    "audit-program-data": "tsx scripts/audit-program-data.ts"
   },
   "dependencies": {
     "@ai-sdk/openai": "^3.0.33",

--- a/scripts/audit-program-data.ts
+++ b/scripts/audit-program-data.ts
@@ -1,0 +1,114 @@
+import fs from "fs";
+import path from "path";
+
+type Course = { code?: string };
+type Requirement = { heading?: string; courses?: unknown[] };
+type Program = { name?: string; requirements?: Requirement[]; url?: string };
+
+type MissingReference = {
+  file: string;
+  program: string;
+  heading: string;
+  reference: string;
+};
+
+const ROOT = process.cwd();
+const COURSES_FILES = ["data/courses.json", "data/courses-full.json"];
+const MAJORS_DIR = path.join(ROOT, "data", "majors");
+
+function readJson<T>(relativePath: string): T {
+  return JSON.parse(fs.readFileSync(path.join(ROOT, relativePath), "utf-8")) as T;
+}
+
+function normalizeCode(code: string): string {
+  return code.toUpperCase().replace(/\s+/g, " ").trim();
+}
+
+function expandCrossListedCode(reference: string): string[] {
+  const normalized = normalizeCode(reference);
+  const match = normalized.match(/^([A-Z]{2,6}(?:\/[A-Z]{2,6})+)\s+(\d{1,3}[A-Z]?)$/);
+  if (!match) return [normalized];
+
+  const departments = match[1].split("/");
+  const number = match[2];
+  return departments.map((dept) => `${dept} ${number}`);
+}
+
+function loadCourseCodes(): Set<string> {
+  const codes = new Set<string>();
+  for (const file of COURSES_FILES) {
+    const courses = readJson<Course[]>(file);
+    for (const course of courses) {
+      if (course.code) codes.add(normalizeCode(course.code));
+    }
+  }
+  return codes;
+}
+
+function isKnownReference(reference: string, courseCodes: Set<string>): boolean {
+  return expandCrossListedCode(reference).some((code) => courseCodes.has(code));
+}
+
+function categorize(reference: string): string {
+  const normalized = normalizeCode(reference);
+  if (/DISCONTINUED|\*\*/.test(normalized)) return "discontinued-or-annotated";
+  if (/^[A-Z]{2,6}\s+\d{3}[A-Z]?[A-Z]{2,6}\s+\d{3}[A-Z]?/.test(normalized)) return "concatenated-course-sequence";
+  if (/^[A-Z]{2,6}\s+\d{3}[A-Z]?\d{3}[A-Z]?/.test(normalized)) return "concatenated-same-subject-sequence";
+  if (/^[A-Z]{2,6}(?:\/[A-Z]{2,6}){2,}\s+\d{1,3}[A-Z]?$/.test(normalized)) return "multi-department-cross-listing";
+  if (/^[A-Z]{2,6}(?:\/[A-Z]{2,6})+\s+\d{1,3}[A-Z]?$/.test(normalized)) return "cross-listing-missing-from-course-catalog";
+  if (/^[A-Z]{2,6}\s+\d{1,3}[A-Z]?$/.test(normalized)) return "missing-from-course-catalog";
+  return "other-format";
+}
+
+function main() {
+  const courseCodes = loadCourseCodes();
+  const files = fs.readdirSync(MAJORS_DIR).filter((file) => file.endsWith(".json")).sort();
+
+  let totalReferences = 0;
+  let knownReferences = 0;
+  const missing: MissingReference[] = [];
+  const categoryCounts = new Map<string, number>();
+  const programCounts = new Map<string, number>();
+
+  for (const file of files) {
+    const program = JSON.parse(fs.readFileSync(path.join(MAJORS_DIR, file), "utf-8")) as Program;
+    for (const requirement of program.requirements ?? []) {
+      for (const value of requirement.courses ?? []) {
+        if (typeof value !== "string" || !value.trim()) continue;
+        totalReferences += 1;
+        if (isKnownReference(value, courseCodes)) {
+          knownReferences += 1;
+          continue;
+        }
+
+        const record = {
+          file,
+          program: program.name ?? file,
+          heading: requirement.heading ?? "Unknown requirement",
+          reference: value,
+        };
+        missing.push(record);
+        const category = categorize(value);
+        categoryCounts.set(category, (categoryCounts.get(category) ?? 0) + 1);
+        programCounts.set(record.program, (programCounts.get(record.program) ?? 0) + 1);
+      }
+    }
+  }
+
+  const categorySummary = [...categoryCounts.entries()].sort((a, b) => b[1] - a[1]);
+  const topPrograms = [...programCounts.entries()].sort((a, b) => b[1] - a[1]).slice(0, 20);
+
+  console.log(JSON.stringify({
+    programFiles: files.length,
+    courseCodes: courseCodes.size,
+    totalRequirementCourseReferences: totalReferences,
+    knownRequirementCourseReferences: knownReferences,
+    missingRequirementCourseReferences: missing.length,
+    knownReferenceCoverage: Number(((knownReferences / totalReferences) * 100).toFixed(1)),
+    categorySummary,
+    topPrograms,
+    sampleMissingReferences: missing.slice(0, 50),
+  }, null, 2));
+}
+
+main();


### PR DESCRIPTION
## Summary
- adds a reproducible program requirement data audit script
- documents first-pass findings in docs/data-quality-audit.md
- identifies 703 unresolved requirement course references out of 16,288 scanned, mostly concatenated sequences and formatting/annotation issues

## Verification
- npm run audit-program-data
- npm run build

Refs #3