### PR TITLE
Add Adviso pilot planning docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ Use Slack for fast capture and discussion. Use these Markdown docs for organized
 - [Product Roadmap](./product-roadmap.md)
 - [Fall 2026 Pilot Plan](./pilot-plan-fall-2026.md)
 - [Brand Positioning](./brand-positioning.md)
+- [Competitive Landscape](./competitive-landscape.md)
 - [Decisions](./decisions.md)
 - [Meeting Notes](./meeting-notes.md)
 - [User Research](./user-research.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,9 +7,12 @@ Use Slack for fast capture and discussion. Use these Markdown docs for organized
 ## Index
 
 - [Product Roadmap](./product-roadmap.md)
+- [Fall 2026 Pilot Plan](./pilot-plan-fall-2026.md)
+- [Brand Positioning](./brand-positioning.md)
 - [Decisions](./decisions.md)
 - [Meeting Notes](./meeting-notes.md)
 - [User Research](./user-research.md)
+- [April 2026 User Research Synthesis](./user-research-synthesis-2026-04.md)
 - [Compliance Notes](./compliance-notes.md)
 - [Operating Notes](./operating-notes.md)
 

--- a/docs/brand-positioning.md
+++ b/docs/brand-positioning.md
@@ -1,0 +1,80 @@
+# Brand Positioning
+
+## Brand idea
+
+Adviso is a calm, trusted academic planning copilot that helps students understand requirements, choose classes, and plan their path through college.
+
+It should feel more like a premium planning workspace than a generic chatbot.
+
+## Voice
+
+Adviso should sound:
+
+- clear
+- calm
+- smart
+- student-friendly
+- trustworthy
+- practical
+- cautious when stakes are high
+
+Adviso should not sound:
+
+- hype-heavy
+- bureaucratic
+- overconfident
+- like it replaces official advisors
+- like generic AI wrapper copy
+
+## Positioning options
+
+### Option A — clearest pilot positioning
+
+> Personalized class planning for UC Davis students.
+
+### Option B — broader product positioning
+
+> Academic planning that makes college requirements understandable.
+
+### Option C — AI-forward positioning
+
+> Your AI copilot for choosing classes, tracking requirements, and planning your path through college.
+
+Recommended for pilot: **Option A**, supported by Option B language. Keep AI present but not the headline until trust is stronger.
+
+## Landing page headline ideas
+
+- Plan your Fall classes with more confidence.
+- Know what to take next quarter — and why.
+- A clearer way to plan your UC Davis schedule.
+- Turn major requirements into a real class plan.
+
+## Subheadline idea
+
+Adviso helps UC Davis students create personalized quarter plans using major requirements, completed courses, prereqs, schedule constraints, and course context — with explanations you can verify.
+
+## Trust language
+
+Use language like:
+
+- Adviso is not an official UC Davis advisor.
+- Always verify final academic decisions with official UC Davis sources or an advisor.
+- Adviso explains what sources and assumptions it used.
+- Transcript upload/paste is optional.
+- We only ask for academic information needed to generate your plan.
+
+## Brand principles
+
+1. **Earn trust before asking for commitment.**
+2. **Show the reasoning, not just the answer.**
+3. **Be useful in under five minutes.**
+4. **Prefer narrow accuracy over broad overclaiming.**
+5. **Make students feel less lost, not more dependent.**
+
+## IP / naming notes
+
+- Standardize spelling as **Adviso** unless there is a deliberate reason to use another form.
+- Audit existing uses of Advizo/Adviza in interview notes, app copy, domains, and repo references.
+- Check domain/social handle availability before public launch.
+- Do a basic trademark search before investing heavily in brand assets.
+- Avoid UC Davis marks/colors/identity in a way that implies official affiliation without approval.

--- a/docs/competitive-landscape.md
+++ b/docs/competitive-landscape.md
@@ -1,0 +1,121 @@
+# Competitive Landscape
+
+_Last updated: 2026-04-30_
+
+## Why this matters
+
+Adviso is not competing only with other AI chatbots. Students already use a fragmented mix of official degree audit tools, advisor appointments, catalog pages, spreadsheets, peer advice, Reddit/TikTok, Rate My Professors, and schedule planners. The best wedge is not “AI advising” in the abstract; it is a fast, explainable next-quarter planning workflow that makes existing academic information usable.
+
+## Landscape map
+
+| Category | Examples | Buyer/user | What they are good at | Where Adviso can differentiate |
+| --- | --- | --- | --- | --- |
+| Enterprise degree planning | Stellic, Ellucian Degree Works | Institutions, registrars, advising orgs | Degree audits, requirement tracking, official records, integrations | Student-led, lightweight, faster pilot motion, conversational explanations, consumer-grade UX |
+| Student success CRM/advising platforms | EAB Navigate360 | Institutions, advising teams, retention teams | Staff workflows, alerts, campaigns, appointments, coordinated care | Focused class-planning product rather than broad institutional CRM; student-first wedge before campus procurement |
+| Academic operations platforms | Coursedog | Registrars, provosts, departments | Scheduling, curriculum, catalog, demand planning, operational workflows | Personal planning layer for students, not back-office scheduling infrastructure |
+| Consumer schedule tools | Coursicle and similar planners | Students | Course lookup, timetable visualization, class alerts, lightweight sharing | Adds requirement reasoning, completed coursework, prereq checks, workload/context explanations |
+| Manual/peer channels | Advisors, friends, Reddit, TikTok, Rate My Professors, spreadsheets | Students | Trust, lived experience, subjective course/professor context | Centralize fragmented info; show assumptions/citations; make peer context useful without becoming rumor-driven |
+
+## Competitor notes
+
+### Stellic
+
+Stellic positions around degree audits, academic planning, registration, and student success. Its Progress product emphasizes real-time degree progress, exploration of major/minor changes, audit-aware multi-year planning, pathways, and optional registration integration.
+
+Implication for Adviso:
+
+- Stellic validates demand for clearer academic progress and planning.
+- It is institution-first and integration-heavy, which likely means longer sales cycles.
+- Adviso should not try to out-enterprise Stellic early. The pilot advantage is speed, specificity, and student-facing usefulness before institutional procurement.
+
+### EAB Navigate360
+
+EAB Navigate360 is a broad higher-ed CRM/student-success platform. It emphasizes staff workflow automation, coordinated care networks, alerts, messaging, appointments, surveys, notes, integrations, and responsible AI. Its AI messaging includes staff capacity, student appointment scheduling, to-dos, course finding aligned with degree progress, and around-the-clock answers.
+
+Implication for Adviso:
+
+- Navigate360 is a broad institutional platform, not a narrow class-planning wedge.
+- Adviso should position as a focused planning workspace students can use immediately, while staying compatible with eventual institution-facing workflows.
+- Do not lead with “student success CRM.” Lead with “get a verified plan for what to take next quarter.”
+
+### Ellucian / Degree Works ecosystem
+
+Ellucian’s student-success positioning centers on helping institutions support students from enrollment to graduation as part of a broader higher-ed system stack. Degree Works is widely understood in the market as a degree audit/planning tool, but the public product pages are embedded in a larger platform story.
+
+Implication for Adviso:
+
+- Official degree audit systems are the trust baseline, not the enemy.
+- Adviso should treat official audits/catalogs as sources to explain, not replace.
+- Product copy should say “Adviso helps you understand and plan around official requirements,” not “Adviso is your source of truth.”
+
+### Coursedog
+
+Coursedog focuses on academic operations: scheduling, curriculum, catalogs, assessment, integrations, and course demand planning. It serves institutional operators more than individual student planners.
+
+Implication for Adviso:
+
+- There is a separate institutional need around forecasting course demand and unblocking pathways.
+- Adviso’s early student plans could eventually produce aggregate demand signals, but only with strong privacy controls and explicit consent.
+- Do not overbuild institutional dashboards before proving student utility.
+
+### Coursicle and consumer planners
+
+Coursicle’s public positioning is “All your academics, all in one place,” with schedule, tasks, reminders, sharing, and chat. Tools in this category usually win on speed, mobile accessibility, alerts, and simple planning.
+
+Implication for Adviso:
+
+- Students already value lightweight planning tools.
+- Adviso must feel as fast and easy as a consumer planner, not like enterprise software.
+- Differentiation should be requirement-aware planning: “why these courses,” “what they unlock,” “what to verify,” and “what tradeoffs this plan creates.”
+
+## Recommended positioning
+
+Use this hierarchy:
+
+1. **Pilot headline:** Personalized class planning for UC Davis students.
+2. **Trust support:** Adviso explains requirements, prereqs, assumptions, and sources so you know what to verify.
+3. **AI framing:** AI-assisted, but not AI-first. AI is the engine; clarity and confidence are the product.
+4. **Institutional posture:** Not official UC Davis advising; designed to complement official sources and advisors.
+
+Avoid these positions for now:
+
+- “Replace your academic advisor.”
+- “The operating system for universities.”
+- “A complete degree audit system.”
+- “Guaranteed graduation planning.”
+
+## Product implications
+
+Near-term features that strengthen differentiation:
+
+1. **Plan explanation blocks:** Every recommended course should say why it appears, which requirement/prereq/course-sequence logic it relates to, and what source/assumption supports it.
+2. **Verification checklist:** Give students a short “before you register, verify these 3 things” checklist.
+3. **Confidence labels:** Mark recommendations as high/medium/low confidence based on data completeness and ambiguity.
+4. **Alternate plan comparison:** Show 2–3 options with tradeoffs: faster progress, lighter workload, schedule fit, prerequisite setup.
+5. **Student feedback loop:** Ask “Would you actually register for this?” and “What would you double-check?” after a plan.
+6. **Privacy-forward transcript path:** Make transcript upload/paste optional and explain storage/retention plainly.
+
+## Go-to-market implications
+
+For the UC Davis pilot:
+
+- Lead with next-quarter/Fall planning, not full four-year planning.
+- Recruit students who are already stressed before registration.
+- Use waitlist language that promises a useful planning session, not a complete advising replacement.
+- Build trust with screenshots/examples showing citations, caveats, and advisor-verification prompts.
+- Keep the cohort small enough to manually review unsafe or uncertain recommendations.
+
+## Open questions
+
+- Which UC Davis majors have enough data confidence to support the first active cohort?
+- Is the first public surface a waitlist page, a guided intake, or a sample plan demo?
+- Should Adviso eventually sell to institutions, remain student-direct, or use student adoption as proof for campus partnerships?
+- What is the acceptable retention policy for transcript-derived information during the pilot?
+
+## Source notes
+
+- Stellic Progress page, fetched 2026-04-30: degree audits, real-time progress, major/minor exploration, audit-aware planner, pathways, registration integration, automated workflows, demand reports. https://www.stellic.com/progress
+- EAB Navigate360 page, fetched 2026-04-30: higher-ed CRM, staff workflows, alerts, messaging, appointments, integrations, AI assistant for staff/students, course finding aligned with degree progress. https://eab.com/solutions/navigate360/
+- Ellucian student-success page, fetched 2026-04-30: broader student lifecycle and student-success platform positioning. https://www.ellucian.com/products/student/student-success
+- Coursedog site fetch, 2026-04-30: academic operations platform, curriculum/scheduling/catalog/assessment, SIS integrations, course demand projections. https://www.coursedog.com/
+- Coursicle homepage, fetched 2026-04-30: schedule, tasks, reminders, sharing, chat; “All your academics, all in one place.” https://www.coursicle.com/

--- a/docs/pilot-plan-fall-2026.md
+++ b/docs/pilot-plan-fall-2026.md
@@ -1,0 +1,102 @@
+# Fall 2026 Pilot Plan
+
+## Pilot thesis
+
+Adviso helps UC Davis students choose Fall quarter classes by combining major requirements, completed coursework, prerequisites, schedule constraints, and course/professor context into a clear, cited academic plan.
+
+## Positioning
+
+Primary promise:
+
+> Get a personalized Fall quarter class plan before registration — with reasons, requirements, prereqs, and schedule tradeoffs explained clearly.
+
+Avoid promising:
+
+- Official UC Davis advising
+- Guaranteed graduation accuracy
+- Full replacement for advisors
+- Perfect support for every major/pathway on day one
+
+## Pilot format
+
+Recommended model: **waitlist + controlled cohort**
+
+- Waitlist can accept students from all UC Davis majors.
+- Initial active pilot should select a smaller cohort for higher-touch review.
+- Start with 10–25 students.
+- Prefer majors where data confidence is high and student pain is clear.
+- Expand only after checking quality and repeated failure modes.
+
+## Target users
+
+Best early users:
+
+- UC Davis undergraduates planning Fall quarter
+- Students who need next-quarter course guidance now
+- Students with scheduling constraints
+- Students unsure how requirements, prereqs, GEs, and professor/course difficulty fit together
+- Students considering major/minor changes, but this should be treated as a higher-risk path
+
+## Core pilot flow
+
+1. Student joins waitlist.
+2. Student provides major, year, goals, and planning concern.
+3. Student optionally provides transcript/completed courses.
+4. Student adds blocked times and preferences.
+5. Adviso generates 2–3 Fall class plan options.
+6. Each option explains:
+   - why these courses
+   - which requirements they may satisfy
+   - prereq assumptions
+   - schedule/workload notes
+   - source basis
+   - uncertainty or “verify with advisor/catalog” warnings
+7. Student gives feedback on usefulness, trust, and next action.
+
+## Success metrics
+
+- Time to first useful plan under 5 minutes
+- 70%+ of pilot users say the plan was useful
+- 60%+ say they understand their requirements better after using Adviso
+- 50%+ say they would use Adviso before Pass 1 registration
+- Zero high-confidence unsafe recommendations discovered in review
+- Track all incorrect, uncertain, or unverifiable recommendations
+
+## Data to capture
+
+Waitlist fields:
+
+- UC Davis email or student email
+- Major(s)
+- Minor/double-major interest
+- Year/class standing
+- Planning for Fall? yes/no
+- Biggest scheduling/planning concern
+- Willing to upload/paste unofficial transcript? yes/no
+- Willing to do 15-minute feedback interview? yes/no
+
+Product feedback:
+
+- Was the plan useful?
+- Did you trust it?
+- What would you verify before acting?
+- What was confusing?
+- What course or requirement did Adviso miss?
+- Would you use this again during registration?
+
+## Risks and mitigations
+
+- **Accuracy risk:** show citations, source categories, and uncertainty.
+- **Privacy risk:** make transcript handling explicit; do not store more than needed.
+- **Trust risk:** use student testimonials, transparent methodology, and careful language.
+- **Scope risk:** waitlist can be broad; active pilot must stay narrow enough to review.
+- **Institutional risk:** do not imply official UC Davis affiliation unless approved.
+
+## Immediate build priorities
+
+1. Merge safety/privacy/onboarding PRs.
+2. Add waitlist landing page.
+3. Add Fall planning intake questions.
+4. Improve first-plan generation and source display.
+5. Add feedback capture after plan generation.
+6. Use data audit output to avoid overconfident advice in low-confidence majors/requirements.

--- a/docs/user-research-synthesis-2026-04.md
+++ b/docs/user-research-synthesis-2026-04.md
@@ -1,0 +1,83 @@
+# User Research Synthesis — April 2026 Interviews
+
+## Source interviews
+
+Six interview PDFs uploaded by Phillip on 2026-04-30. The synthesis intentionally avoids storing participant full names in the repo doc; use the original private interview files if attribution is needed.
+
+Participant mix:
+
+- UC Davis students, including Biological Sciences students
+- One College of San Mateo student with transfer-oriented planning needs
+- Interviews covered scheduling, advising, AI trust, prototype reactions, privacy, and planning workflows
+
+## Executive summary
+
+The interviews validate a strong student pain around academic planning, especially when students are choosing classes under time pressure. The strongest wedge is not a generic AI chatbot; it is a trusted class-planning workflow that helps students choose next-quarter classes, understand requirements, avoid prereq/schedule mistakes, and see why recommendations are safe.
+
+The biggest adoption blocker is trust. Students like the idea when it saves them time, reduces uncertainty, or centralizes scattered information, but they are cautious about AI accuracy, privacy, brand credibility, and whether the product understands UC Davis-specific data.
+
+## Repeated pain points
+
+1. **Advisor access is too slow during registration periods**
+   - Students struggle to get appointments when they most need help.
+   - Advising bottlenecks are especially painful around pass times.
+
+2. **Current schedule planning tools do not answer “what should I take?”**
+   - Schedule Builder can show courses, but students still need to interpret requirements, sequencing, prereqs, GEs, and tradeoffs themselves.
+   - Several students described self-advising or relying on fragmented outside resources.
+
+3. **Trust and accuracy are the core adoption barriers**
+   - Students worry that generic AI lacks UC Davis-specific knowledge.
+   - Students want verification, transparency, official-looking sources, or institutional credibility.
+
+4. **Students already seek unofficial planning signals**
+   - Rate My Professor, catalog pages, Reddit, TikTok, and peer advice are used to fill gaps.
+   - This creates an opening for Adviso as a centralized, cleaner source of planning context.
+
+5. **Personal constraints matter**
+   - Time blocking and external commitments are important.
+   - Students want recommendations that account for work, practice, commuting, and preferred schedule shape.
+
+6. **Degree audit needs more depth**
+   - Students want minors, double majors, restricted electives, GEs, complex pathways, and long-term sequencing handled clearly.
+
+## Strong quotes and implications
+
+- “I feel like I could trust something like that as long as it's secure.” — trust/privacy must be visible in-product.
+- “I feel like there could be more help with guidance about what classes a student should take.” — next-quarter planning is a validated wedge.
+- “I base my schedule off of timing... I have outside commitments.” — schedule generation must respect blocked times and preferences.
+- “I wouldn't trust it at all. I would need to look before.” — citations, verification, and trust-building are non-negotiable.
+- “The most important part of starting up this business is to advertise it well and gain trust.” — go-to-market is a credibility problem, not just awareness.
+- “I found myself a lot of times just going on Reddit or trying to find on TikTok things like this.” — Adviso can centralize scattered student knowledge.
+- “My biggest fear is like AI stealing my data.” — privacy language should be plain, early, and repeated.
+
+## What is validated
+
+- Students feel real friction around academic planning and registration.
+- A next-quarter/fall-class planning assistant is a concrete and valuable use case.
+- Students want a tool that combines requirements, professor/course signals, scheduling constraints, and personalized goals.
+- Time blocking and schedule optimization resonated in prototype reactions.
+- Students are open to AI when the value is clear and trust concerns are handled.
+
+## What is not yet validated
+
+- Whether students will trust Adviso without institutional endorsement.
+- Whether students will pay directly; interview evidence points away from subscription as the primary initial motion.
+- Whether current degree-audit data is accurate enough for broad autonomous planning.
+- Whether all UC Davis majors can be supported at the same quality level in the first pilot.
+
+## Product implications
+
+1. The pilot should focus on **Fall quarter class planning**.
+2. The product should generate a clear first plan, not drop students into empty chat.
+3. Every recommendation should show source basis, prereq assumptions, and uncertainty.
+4. Adviso should collect student constraints: major, year, completed courses/transcript, blocked times, goals, preferred workload, and risk tolerance.
+5. The product should avoid claiming official UC Davis authority unless a real partnership exists.
+6. Early waitlist can accept broad majors, but the first pilot cohort should be controlled and reviewed.
+
+## Recommended next research
+
+- Run 5–8 more interviews specifically around the Fall-planning workflow.
+- Test a clickable or live flow where a student gets 2–3 plan options.
+- Ask students to rate trust before and after seeing citations/source notes.
+- Test waitlist messaging: “Fall class plan” vs “AI academic advisor” vs “degree planning copilot.”


### PR DESCRIPTION
## Summary
- adds anonymized April 2026 user research synthesis from uploaded interview material
- adds a Fall 2026 waitlist/controlled-cohort pilot plan focused on next-quarter class planning
- adds brand positioning guidance for Adviso voice, trust language, and pilot messaging
- updates docs index with the new planning docs

## Verification
- checked docs for participant names before commit
- git diff --check

Note: no app code changed.